### PR TITLE
[BE] 메인 페이지(컬럼+카드)를 불러오는 기능 구현

### DIFF
--- a/BE/app/src/main/java/com/todo/app/common/ApiResponse.java
+++ b/BE/app/src/main/java/com/todo/app/common/ApiResponse.java
@@ -7,8 +7,8 @@ public class ApiResponse<T> {
     private int statusCode;
     private T message;
 
-    public ApiResponse(int statusCode, T message) {
-        this.statusCode = statusCode;
+    public ApiResponse(HttpStatus status, T message) {
+        this.statusCode = status.value();
         this.message = message;
     }
 
@@ -21,6 +21,6 @@ public class ApiResponse<T> {
     }
 
     public static <T> ApiResponse<T> success(HttpStatus status, T message) {
-        return new ApiResponse<>(status.value(), message);
+        return new ApiResponse<>(status, message);
     }
 }

--- a/BE/app/src/main/java/com/todo/app/common/ApiResponse.java
+++ b/BE/app/src/main/java/com/todo/app/common/ApiResponse.java
@@ -23,4 +23,8 @@ public class ApiResponse<T> {
     public static <T> ApiResponse<T> success(HttpStatus status, T message) {
         return new ApiResponse<>(status, message);
     }
+
+    public static <String> ApiResponse<String> exception(HttpStatus status, String message) {
+        return new ApiResponse<>(status, message);
+    }
 }

--- a/BE/app/src/main/java/com/todo/app/common/ApiResponse.java
+++ b/BE/app/src/main/java/com/todo/app/common/ApiResponse.java
@@ -1,0 +1,26 @@
+package com.todo.app.common;
+
+import org.springframework.http.HttpStatus;
+
+public class ApiResponse<T> {
+
+    private int statusCode;
+    private T message;
+
+    public ApiResponse(int statusCode, T message) {
+        this.statusCode = statusCode;
+        this.message = message;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public T getMessage() {
+        return message;
+    }
+
+    public static <T> ApiResponse<T> success(HttpStatus status, T message) {
+        return new ApiResponse<>(status.value(), message);
+    }
+}

--- a/BE/app/src/main/java/com/todo/app/common/config/RedisConfig.java
+++ b/BE/app/src/main/java/com/todo/app/common/config/RedisConfig.java
@@ -1,0 +1,66 @@
+package com.todo.app.common.config;
+
+import java.time.Duration;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching
+public class RedisConfig {
+    private final RedisProperties redisProperties;
+
+    public RedisConfig(RedisProperties redisProperties) {
+        this.redisProperties = redisProperties;
+    }
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisConnectionFactory = new RedisStandaloneConfiguration();
+
+        redisConnectionFactory.setHostName(redisProperties.getHost());
+        redisConnectionFactory.setPort(redisProperties.getPort());
+
+        return new LettuceConnectionFactory(redisConnectionFactory);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+
+        // Redis key와 value를 JSON 문자열로 직렬화하는 Serializer 설정
+        template.setDefaultSerializer(new GenericJackson2JsonRedisSerializer());
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return template;
+    }
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration
+                .defaultCacheConfig()
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
+                        new GenericJackson2JsonRedisSerializer()))
+                .entryTtl(Duration.ofMinutes(3L)); // Time to live
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
+    }
+}
+

--- a/BE/app/src/main/java/com/todo/app/common/exception/GlobalExceptionHandler.java
+++ b/BE/app/src/main/java/com/todo/app/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.todo.app.common.exception;
+
+import com.todo.app.common.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    public ApiResponse<String> handleException(Exception ex) {
+        return ApiResponse.exception(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
+    }
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ApiResponse<String> handleException(ResourceNotFoundException ex) {
+        return ApiResponse.exception(ex.getHttpStatus(), ex.getMessage());
+    }
+}

--- a/BE/app/src/main/java/com/todo/app/common/exception/ResourceNotFoundException.java
+++ b/BE/app/src/main/java/com/todo/app/common/exception/ResourceNotFoundException.java
@@ -1,0 +1,16 @@
+package com.todo.app.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class ResourceNotFoundException extends RuntimeException {
+
+    private final HttpStatus httpStatus = HttpStatus.NOT_FOUND;
+
+    public ResourceNotFoundException(String datasource, long id) {
+        super(datasource + "에서 ID " + id + "를 찾을 수 없습니다.");
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+}

--- a/BE/app/src/main/java/com/todo/app/domain/column/controller/ColumnController.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/controller/ColumnController.java
@@ -3,6 +3,7 @@ package com.todo.app.domain.column.controller;
 import com.todo.app.common.ApiResponse;
 import com.todo.app.domain.column.controller.response.ColumnResponse;
 import com.todo.app.domain.column.service.ColumnService;
+import com.todo.app.domain.column.service.ColumnServiceImpl;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.http.HttpStatus;

--- a/BE/app/src/main/java/com/todo/app/domain/column/controller/ColumnController.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/controller/ColumnController.java
@@ -1,0 +1,28 @@
+package com.todo.app.domain.column.controller;
+
+import com.todo.app.common.ApiResponse;
+import com.todo.app.domain.column.controller.response.ColumnResponse;
+import com.todo.app.domain.column.service.ColumnService;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ColumnController {
+
+    private final ColumnService columnService;
+
+    public ColumnController(ColumnService columnService) {
+        this.columnService = columnService;
+    }
+
+    @GetMapping("/api/columns")
+    public ApiResponse<List<ColumnResponse>> readColumns() {
+        List<ColumnResponse> columnResponses = columnService.readAll(1L).stream()// TODO: 로그인 기능 구현 후 readAll() 파라미터 수정 필요
+                .map(ColumnResponse::from)
+                .collect(Collectors.toList());
+        return ApiResponse.success(HttpStatus.OK, columnResponses);
+    }
+}

--- a/BE/app/src/main/java/com/todo/app/domain/column/controller/response/CardResponse.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/controller/response/CardResponse.java
@@ -1,6 +1,6 @@
 package com.todo.app.domain.column.controller.response;
 
-import com.todo.app.domain.column.entity.Card;
+import com.todo.app.domain.column.domain.Card;
 
 public class CardResponse {
 

--- a/BE/app/src/main/java/com/todo/app/domain/column/controller/response/CardResponse.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/controller/response/CardResponse.java
@@ -1,0 +1,32 @@
+package com.todo.app.domain.column.controller.response;
+
+import com.todo.app.domain.column.entity.Card;
+
+public class CardResponse {
+
+    private Long id;
+    private String title;
+    private String content;
+
+    public CardResponse(Long id, String title, String content) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public static CardResponse from(Card card) {
+        return new CardResponse(card.getId(), card.getTitle(), card.getContent());
+    }
+}

--- a/BE/app/src/main/java/com/todo/app/domain/column/controller/response/ColumnResponse.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/controller/response/ColumnResponse.java
@@ -1,6 +1,6 @@
 package com.todo.app.domain.column.controller.response;
 
-import com.todo.app.domain.column.entity.Column;
+import com.todo.app.domain.column.domain.Column;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/BE/app/src/main/java/com/todo/app/domain/column/controller/response/ColumnResponse.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/controller/response/ColumnResponse.java
@@ -1,0 +1,37 @@
+package com.todo.app.domain.column.controller.response;
+
+import com.todo.app.domain.column.entity.Column;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ColumnResponse {
+
+    private Long columnId;
+    private String columnTitle;
+    private List<CardResponse> cards;
+
+    public ColumnResponse(Long columnId, String columnTitle, List<CardResponse> cards) {
+        this.columnId = columnId;
+        this.columnTitle = columnTitle;
+        this.cards = cards;
+    }
+
+    public static ColumnResponse from(Column column) {
+        List<CardResponse> cardResponses = column.getCards().stream()
+                .map(CardResponse::from)
+                .collect(Collectors.toList());
+        return new ColumnResponse(column.getId(), column.getTitle(), cardResponses);
+    }
+
+    public Long getColumnId() {
+        return columnId;
+    }
+
+    public String getColumnTitle() {
+        return columnTitle;
+    }
+
+    public List<CardResponse> getCards() {
+        return cards;
+    }
+}

--- a/BE/app/src/main/java/com/todo/app/domain/column/controller/response/Response.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/controller/response/Response.java
@@ -1,4 +1,0 @@
-package com.todo.app.domain.column.controller.response;
-
-public class Response {
-}

--- a/BE/app/src/main/java/com/todo/app/domain/column/domain/Card.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/domain/Card.java
@@ -1,4 +1,4 @@
-package com.todo.app.domain.column.entity;
+package com.todo.app.domain.column.domain;
 
 public class Card {
 

--- a/BE/app/src/main/java/com/todo/app/domain/column/domain/Column.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/domain/Column.java
@@ -1,6 +1,8 @@
-package com.todo.app.domain.column.entity;
+package com.todo.app.domain.column.domain;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class Column {
 
@@ -33,5 +35,17 @@ public class Column {
 
     public List<Card> getCards() {
         return cards;
+    }
+
+    public void matchCards(List<Card> cards) {
+        List<Card> temp = new ArrayList<>();
+
+        for (Card card : cards) {
+            if (Objects.equals(id, card.getColumnId())) {
+                temp.add(card);
+            }
+        }
+
+        this.cards = temp;
     }
 }

--- a/BE/app/src/main/java/com/todo/app/domain/column/entity/Card.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/entity/Card.java
@@ -1,0 +1,39 @@
+package com.todo.app.domain.column.entity;
+
+public class Card {
+
+    private Long id;
+    private Long columnId;
+    private String title;
+    private String content;
+    private String author;
+
+    public Card(Long id, Long columnId, String title, String content, String author) {
+        this.id = id;
+        this.columnId = columnId;
+        this.title = title;
+        this.content = content;
+        this.author = author;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getColumnId() {
+        return columnId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+}

--- a/BE/app/src/main/java/com/todo/app/domain/column/entity/CardEntity.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/entity/CardEntity.java
@@ -1,0 +1,45 @@
+package com.todo.app.domain.column.entity;
+
+import com.todo.app.domain.column.domain.Card;
+
+public class CardEntity {
+
+    private Long id;
+    private Long columnId;
+    private String title;
+    private String content;
+    private String author;
+
+
+    public CardEntity(Long id, Long columnId, String title, String content, String author) {
+        this.id = id;
+        this.columnId = columnId;
+        this.title = title;
+        this.content = content;
+        this.author = author;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getColumnId() {
+        return columnId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public Card toDomain() {
+        return new Card(id, columnId, title, content, author);
+    }
+}

--- a/BE/app/src/main/java/com/todo/app/domain/column/entity/Column.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/entity/Column.java
@@ -1,0 +1,37 @@
+package com.todo.app.domain.column.entity;
+
+import java.util.List;
+
+public class Column {
+
+    private final Long id;
+    private final Long memberId;
+    private String title;
+    private List<Card> cards;
+
+    public Column(Long id, Long memberId, String title) {
+        this.id = id;
+        this.memberId = memberId;
+        this.title = title;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setCards(List<Card> cards) {
+        this.cards = cards;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public List<Card> getCards() {
+        return cards;
+    }
+}

--- a/BE/app/src/main/java/com/todo/app/domain/column/entity/ColumnEntity.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/entity/ColumnEntity.java
@@ -1,0 +1,32 @@
+package com.todo.app.domain.column.entity;
+
+import com.todo.app.domain.column.domain.Column;
+
+public class ColumnEntity {
+
+    private final Long id;
+    private final Long memberId;
+    private final String title;
+
+    public ColumnEntity(Long id, Long memberId, String title) {
+        this.id = id;
+        this.memberId = memberId;
+        this.title = title;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public Column toDomain() {
+        return new Column(id, memberId, title);
+    }
+}

--- a/BE/app/src/main/java/com/todo/app/domain/column/entity/Entity.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/entity/Entity.java
@@ -1,4 +1,0 @@
-package com.todo.app.domain.column.entity;
-
-public class Entity {
-}

--- a/BE/app/src/main/java/com/todo/app/domain/column/repository/CardRepository.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/repository/CardRepository.java
@@ -1,6 +1,6 @@
 package com.todo.app.domain.column.repository;
 
-import com.todo.app.domain.column.entity.Card;
+import com.todo.app.domain.column.domain.Card;
 import java.util.List;
 
 public interface CardRepository {

--- a/BE/app/src/main/java/com/todo/app/domain/column/repository/CardRepository.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/repository/CardRepository.java
@@ -1,0 +1,9 @@
+package com.todo.app.domain.column.repository;
+
+import com.todo.app.domain.column.entity.Card;
+import java.util.List;
+
+public interface CardRepository {
+
+    List<Card> findAllBy(Long memberId);
+}

--- a/BE/app/src/main/java/com/todo/app/domain/column/repository/CardRepositoryImpl.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/repository/CardRepositoryImpl.java
@@ -1,8 +1,10 @@
 package com.todo.app.domain.column.repository;
 
-import com.todo.app.domain.column.entity.Card;
+import com.todo.app.domain.column.domain.Card;
+import com.todo.app.domain.column.entity.CardEntity;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -25,11 +27,14 @@ public class CardRepositoryImpl implements CardRepository {
                 + "WHERE card.deleted = 0 "
                 + "AND member_id = :memberId";
 
-        return template.query(sql, Map.of("memberId", memberId), cardRowMapper());
+        return template.query(sql, Map.of("memberId", memberId), cardRowMapper())
+                .stream()
+                .map(CardEntity::toDomain)
+                .collect(Collectors.toList());
     }
 
-    private RowMapper<Card> cardRowMapper() {
-        return (rs, rowNum) -> new Card(
+    private RowMapper<CardEntity> cardRowMapper() {
+        return (rs, rowNum) -> new CardEntity(
                 rs.getLong("id"),
                 rs.getLong("tdl_column_id"),
                 rs.getString("title"),

--- a/BE/app/src/main/java/com/todo/app/domain/column/repository/CardRepositoryImpl.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/repository/CardRepositoryImpl.java
@@ -1,0 +1,40 @@
+package com.todo.app.domain.column.repository;
+
+import com.todo.app.domain.column.entity.Card;
+import java.util.List;
+import java.util.Map;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class CardRepositoryImpl implements CardRepository {
+
+    private final NamedParameterJdbcTemplate template;
+
+    public CardRepositoryImpl(NamedParameterJdbcTemplate template) {
+        this.template = template;
+    }
+
+    @Override
+    public List<Card> findAllBy(Long memberId) {
+        String sql = "SELECT card.id, tdl_column_id, card.title, content, author "
+                + "FROM tdl_card card "
+                + "LEFT JOIN tdl_column as cl "
+                + "ON tdl_column_id = cl.id "
+                + "WHERE card.deleted = 0 "
+                + "AND member_id = :memberId";
+
+        return template.query(sql, Map.of("memberId", memberId), cardRowMapper());
+    }
+
+    private RowMapper<Card> cardRowMapper() {
+        return (rs, rowNum) -> new Card(
+                rs.getLong("id"),
+                rs.getLong("tdl_column_id"),
+                rs.getString("title"),
+                rs.getString("content"),
+                rs.getString("author")
+        );
+    }
+}

--- a/BE/app/src/main/java/com/todo/app/domain/column/repository/ColumnRepository.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/repository/ColumnRepository.java
@@ -1,6 +1,6 @@
 package com.todo.app.domain.column.repository;
 
-import com.todo.app.domain.column.entity.Column;
+import com.todo.app.domain.column.domain.Column;
 import java.util.List;
 
 public interface ColumnRepository {

--- a/BE/app/src/main/java/com/todo/app/domain/column/repository/ColumnRepository.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/repository/ColumnRepository.java
@@ -1,0 +1,8 @@
+package com.todo.app.domain.column.repository;
+
+import com.todo.app.domain.column.entity.Column;
+import java.util.List;
+
+public interface ColumnRepository {
+    List<Column> findAllBy(Long memberId);
+}

--- a/BE/app/src/main/java/com/todo/app/domain/column/repository/ColumnRepositoryImpl.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/repository/ColumnRepositoryImpl.java
@@ -1,8 +1,10 @@
 package com.todo.app.domain.column.repository;
 
-import com.todo.app.domain.column.entity.Column;
+import com.todo.app.domain.column.domain.Column;
+import com.todo.app.domain.column.entity.ColumnEntity;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -19,11 +21,14 @@ public class ColumnRepositoryImpl implements ColumnRepository {
     @Override
     public List<Column> findAllBy(Long memberId) {
         String sql = "SELECT id, member_id, title FROM tdl_column WHERE deleted = 0 AND member_id = :memberId";
-        return template.query(sql, Map.of("memberId", memberId), columnRowMapper());
+        return template.query(sql, Map.of("memberId", memberId), columnRowMapper())
+                .stream()
+                .map(ColumnEntity::toDomain)
+                .collect(Collectors.toList());
     }
 
-    private RowMapper<Column> columnRowMapper() {
-        return (rs, rowNum) -> new Column(
+    private RowMapper<ColumnEntity> columnRowMapper() {
+        return (rs, rowNum) -> new ColumnEntity(
                 rs.getLong("id"),
                 rs.getLong("member_id"),
                 rs.getString("title")

--- a/BE/app/src/main/java/com/todo/app/domain/column/repository/ColumnRepositoryImpl.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/repository/ColumnRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.todo.app.domain.column.repository;
 
+import com.todo.app.common.exception.ResourceNotFoundException;
 import com.todo.app.domain.column.domain.Column;
 import com.todo.app.domain.column.entity.ColumnEntity;
 import java.util.List;

--- a/BE/app/src/main/java/com/todo/app/domain/column/repository/ColumnRepositoryImpl.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/repository/ColumnRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.todo.app.domain.column.repository;
+
+import com.todo.app.domain.column.entity.Column;
+import java.util.List;
+import java.util.Map;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ColumnRepositoryImpl implements ColumnRepository {
+
+    private final NamedParameterJdbcTemplate template;
+
+    public ColumnRepositoryImpl(NamedParameterJdbcTemplate template) {
+        this.template = template;
+    }
+
+    @Override
+    public List<Column> findAllBy(Long memberId) {
+        String sql = "SELECT id, member_id, title FROM tdl_column WHERE deleted = 0 AND member_id = :memberId";
+        return template.query(sql, Map.of("memberId", memberId), columnRowMapper());
+    }
+
+    private RowMapper<Column> columnRowMapper() {
+        return (rs, rowNum) -> new Column(
+                rs.getLong("id"),
+                rs.getLong("member_id"),
+                rs.getString("title")
+        );
+    }
+}

--- a/BE/app/src/main/java/com/todo/app/domain/column/repository/Repository.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/repository/Repository.java
@@ -1,4 +1,0 @@
-package com.todo.app.domain.column.repository;
-
-public class Repository {
-}

--- a/BE/app/src/main/java/com/todo/app/domain/column/service/ColumnService.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/service/ColumnService.java
@@ -1,7 +1,7 @@
 package com.todo.app.domain.column.service;
 
-import com.todo.app.domain.column.entity.Card;
-import com.todo.app.domain.column.entity.Column;
+import com.todo.app.domain.column.domain.Card;
+import com.todo.app.domain.column.domain.Column;
 import com.todo.app.domain.column.repository.CardRepository;
 import com.todo.app.domain.column.repository.ColumnRepository;
 import java.util.ArrayList;
@@ -20,21 +20,14 @@ public class ColumnService {
         this.cardRepository = cardRepository;
     }
 
-    // TODO: 로직 개선 필요...
     public List<Column> readAll(Long memberId) {
         List<Column> columns = columnRepository.findAllBy(memberId);
         List<Card> cards = cardRepository.findAllBy(memberId);
 
         for (Column column : columns) {
-            List<Card> tmp = new ArrayList<>();
-
-            for (Card card : cards) {
-                if (Objects.equals(column.getId(), card.getColumnId())) {
-                    tmp.add(card);
-                }
-            }
-            column.setCards(tmp);
+            column.matchCards(cards);
         }
+        
         return columns;
     }
 

--- a/BE/app/src/main/java/com/todo/app/domain/column/service/ColumnService.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/service/ColumnService.java
@@ -1,5 +1,6 @@
 package com.todo.app.domain.column.service;
 
+import com.todo.app.common.exception.ResourceNotFoundException;
 import com.todo.app.domain.column.domain.Card;
 import com.todo.app.domain.column.domain.Column;
 import com.todo.app.domain.column.repository.CardRepository;
@@ -27,7 +28,7 @@ public class ColumnService {
         for (Column column : columns) {
             column.matchCards(cards);
         }
-        
+
         return columns;
     }
 

--- a/BE/app/src/main/java/com/todo/app/domain/column/service/ColumnService.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/service/ColumnService.java
@@ -1,35 +1,8 @@
 package com.todo.app.domain.column.service;
 
-import com.todo.app.common.exception.ResourceNotFoundException;
-import com.todo.app.domain.column.domain.Card;
 import com.todo.app.domain.column.domain.Column;
-import com.todo.app.domain.column.repository.CardRepository;
-import com.todo.app.domain.column.repository.ColumnRepository;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-import org.springframework.stereotype.Service;
 
-@Service
-public class ColumnService {
-
-    private final ColumnRepository columnRepository;
-    private final CardRepository cardRepository;
-
-    public ColumnService(ColumnRepository columnRepository, CardRepository cardRepository) {
-        this.columnRepository = columnRepository;
-        this.cardRepository = cardRepository;
-    }
-
-    public List<Column> readAll(Long memberId) {
-        List<Column> columns = columnRepository.findAllBy(memberId);
-        List<Card> cards = cardRepository.findAllBy(memberId);
-
-        for (Column column : columns) {
-            column.matchCards(cards);
-        }
-
-        return columns;
-    }
-
+public interface ColumnService {
+    List<Column> readAll(Long memberId);
 }

--- a/BE/app/src/main/java/com/todo/app/domain/column/service/ColumnService.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/service/ColumnService.java
@@ -1,0 +1,41 @@
+package com.todo.app.domain.column.service;
+
+import com.todo.app.domain.column.entity.Card;
+import com.todo.app.domain.column.entity.Column;
+import com.todo.app.domain.column.repository.CardRepository;
+import com.todo.app.domain.column.repository.ColumnRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ColumnService {
+
+    private final ColumnRepository columnRepository;
+    private final CardRepository cardRepository;
+
+    public ColumnService(ColumnRepository columnRepository, CardRepository cardRepository) {
+        this.columnRepository = columnRepository;
+        this.cardRepository = cardRepository;
+    }
+
+    // TODO: 로직 개선 필요...
+    public List<Column> readAll(Long memberId) {
+        List<Column> columns = columnRepository.findAllBy(memberId);
+        List<Card> cards = cardRepository.findAllBy(memberId);
+
+        for (Column column : columns) {
+            List<Card> tmp = new ArrayList<>();
+
+            for (Card card : cards) {
+                if (Objects.equals(column.getId(), card.getColumnId())) {
+                    tmp.add(card);
+                }
+            }
+            column.setCards(tmp);
+        }
+        return columns;
+    }
+
+}

--- a/BE/app/src/main/java/com/todo/app/domain/column/service/ColumnServiceImpl.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/service/ColumnServiceImpl.java
@@ -1,0 +1,33 @@
+package com.todo.app.domain.column.service;
+
+import com.todo.app.domain.column.domain.Card;
+import com.todo.app.domain.column.domain.Column;
+import com.todo.app.domain.column.repository.CardRepository;
+import com.todo.app.domain.column.repository.ColumnRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ColumnServiceImpl implements ColumnService{
+
+    private final ColumnRepository columnRepository;
+    private final CardRepository cardRepository;
+
+    public ColumnServiceImpl(ColumnRepository columnRepository, CardRepository cardRepository) {
+        this.columnRepository = columnRepository;
+        this.cardRepository = cardRepository;
+    }
+
+    @Override
+    public List<Column> readAll(Long memberId) {
+        List<Column> columns = columnRepository.findAllBy(memberId);
+        List<Card> cards = cardRepository.findAllBy(memberId);
+
+        for (Column column : columns) {
+            column.matchCards(cards);
+        }
+
+        return columns;
+    }
+
+}

--- a/BE/app/src/main/java/com/todo/app/domain/column/service/Service.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/service/Service.java
@@ -1,4 +1,0 @@
-package com.todo.app.domain.column.service;
-
-public class Service {
-}

--- a/BE/app/src/test/java/com/todo/app/domain/column/controller/ColumnControllerTest.java
+++ b/BE/app/src/test/java/com/todo/app/domain/column/controller/ColumnControllerTest.java
@@ -1,0 +1,91 @@
+package com.todo.app.domain.column.controller;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.todo.app.domain.column.controller.response.CardResponse;
+import com.todo.app.domain.column.controller.response.ColumnResponse;
+import com.todo.app.domain.column.domain.Card;
+import com.todo.app.domain.column.domain.Column;
+import com.todo.app.domain.column.service.ColumnService;
+import com.todo.app.domain.column.service.ColumnServiceImpl;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.stubbing.Answer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@WebMvcTest(controllers = ColumnController.class)
+class ColumnControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    ColumnServiceImpl columnService;
+
+    @DisplayName("사용자는 컬럼 목록과 컬럼에 해당하는 카드 목록을 볼 수 있다.")
+    @Test
+    void testReadColumns() throws Exception {
+/*        CardResponse card1 = new CardResponse(1L,  "GitHub 공부하기", "stash 개념 학습하기");
+        CardResponse card2 = new CardResponse(2L,  "스터디 발표 준비", "데이터베이스 파티셔닝 자료 조사");
+
+        CardResponse card3 = new CardResponse(3L,  "알고리즘 문제 풀기", "백준 14712, 15662번 풀기");
+        CardResponse card4 = new CardResponse(4L,  "AWS 공부하기", "EC2, RDS 개념 학습");
+
+        CardResponse card5 = new CardResponse(5L,  "React 공부하기", "상태 관리 학습하기");
+        CardResponse card6 = new CardResponse(6L,  "WAS 미션 1단계 수행", "POST로 회원가입 구현하기");
+
+        ColumnResponse column1 = new ColumnResponse(1L, "해야 할 일", Arrays.asList(card1, card2));
+        ColumnResponse column2 = new ColumnResponse(2L, "하고 있는 일", Arrays.asList(card3, card4));
+        ColumnResponse column3 = new ColumnResponse(3L, "완료한 일", Arrays.asList(card5, card6));
+
+        List<ColumnResponse> columns = Arrays.asList(column1, column2, column3);
+*/
+        //given(columnService.readAll(anyLong())).willAnswer((Answer<?>) columns);
+
+        Card card1 = new Card(1L,  1L, "GitHub 공부하기", "stash 개념 학습하기", "web");
+        Card card2 = new Card(2L,  1L, "스터디 발표 준비", "데이터베이스 파티셔닝 자료 조사", "web");
+        Card card3 = new Card(3L, 2L, "알고리즘 문제 풀기", "백준 14712, 15662번 풀기", "web");
+        Card card4 = new Card(4L, 2L,  "AWS 공부하기", "EC2, RDS 개념 학습", "web");
+        Card card5 = new Card(5L,  3L, "React 공부하기", "상태 관리 학습하기", "web");
+        Card card6 = new Card(6L,  3L, "WAS 미션 1단계 수행", "POST로 회원가입 구현하기", "web");
+        List<Card> cards = Arrays.asList(card1, card2, card3, card4, card5, card6);
+
+        Column column1 = new Column(1L, 1L, "해야 할 일");
+        Column column2 = new Column(2L, 1L, "하고 있는 일");
+        Column column3 = new Column(3L, 1L, "완료한 일");
+
+        column1.matchCards(cards);
+        column2.matchCards(cards);
+        column3.matchCards(cards);
+
+        List<Column> columns = Arrays.asList(column1, column2, column3);
+
+        when(columnService.readAll(anyLong())).thenReturn(columns);
+
+        mockMvc.perform(
+                        MockMvcRequestBuilders.get("/api/columns"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(200));
+
+    }
+
+
+}


### PR DESCRIPTION
## What is this PR? 👓
- 메인 페이지(컬럼+카드)를 불러오는 기능 구현

## Key changes 🔑
- [X] Card 엔티티, DTO 생성
- [X] Column 엔티티, DTO 생성
- [X] CardRepository - 특정 회원의 모든 카드를 조회하는 기능 구현
- [X] ColumnRepository - 특정 회원의 모든 컬럼을 조회하는 기능 구현
- [X] ColumnService - 특정 회원의 모든 컬럼과 카드를 조회하여 컬럼별로 하나의 엔티티로 조합하는 기능 구현
- [X] ColumnController - 메인 페이지(컬럼+카드)를 불러오는 기능 구현

## To reviewers 👋
 - 특정 회원의 모든 컬럼과 카드를 조회하여 컬럼별로 하나의 엔티티로 조합하는 것이 좋은지 잘 모르겠습니다.