### PR TITLE
[BE] 카드 생성, 제목/내용 수정, 삭제 임시 API 추가

### DIFF
--- a/BE/app/src/main/java/com/todo/app/common/exception/GlobalExceptionHandler.java
+++ b/BE/app/src/main/java/com/todo/app/common/exception/GlobalExceptionHandler.java
@@ -13,6 +13,11 @@ public class GlobalExceptionHandler {
         return ApiResponse.exception(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
     }
 
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ApiResponse<String> handleException(IllegalArgumentException ex) {
+        return ApiResponse.exception(HttpStatus.BAD_REQUEST, ex.getMessage());
+    }
+
     @ExceptionHandler(ResourceNotFoundException.class)
     public ApiResponse<String> handleException(ResourceNotFoundException ex) {
         return ApiResponse.exception(ex.getHttpStatus(), ex.getMessage());

--- a/BE/app/src/main/java/com/todo/app/domain/column/controller/CardController.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/controller/CardController.java
@@ -1,13 +1,18 @@
 package com.todo.app.domain.column.controller;
 
 import com.todo.app.common.ApiResponse;
+import com.todo.app.domain.column.controller.request.ActionRequestType;
 import com.todo.app.domain.column.controller.request.CardCreateRequest;
+import com.todo.app.domain.column.controller.request.CardUpdateRequest;
 import com.todo.app.domain.column.controller.response.CardResponse;
 import com.todo.app.domain.column.service.CardService;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -24,6 +29,18 @@ public class CardController {
         return ApiResponse.success(
                 HttpStatus.OK,
                 CardResponse.from(cardService.create(createRequest.toCardCreate(columnId)))
+        );
+    }
+
+    @PatchMapping("/api/columns/{columnId}/cards/{cardId}")
+    public ApiResponse<CardResponse> updateCard(@RequestBody CardUpdateRequest updateRequest, @PathVariable Long columnId, @PathVariable Long cardId, @RequestParam String action) {
+        if(!ActionRequestType.isUpdate(action)) {
+            throw new IllegalArgumentException(action + "은 올바른 입력값이 아닙니다.");
+        }
+
+        return ApiResponse.success(
+                HttpStatus.OK,
+                CardResponse.from(cardService.update(updateRequest.toCardUpdate(), columnId))
         );
     }
 

--- a/BE/app/src/main/java/com/todo/app/domain/column/controller/CardController.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/controller/CardController.java
@@ -44,4 +44,14 @@ public class CardController {
         );
     }
 
+    @DeleteMapping("/api/columns/{columnId}/cards/{cardId}")
+    public ApiResponse<String> deleteCard(@PathVariable Long columnId, @PathVariable Long cardId) {
+        cardService.delete(cardId);
+
+        return ApiResponse.success(
+                HttpStatus.OK,
+                HttpStatus.OK.getReasonPhrase()
+        );
+    }
+
 }

--- a/BE/app/src/main/java/com/todo/app/domain/column/controller/CardController.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/controller/CardController.java
@@ -1,0 +1,30 @@
+package com.todo.app.domain.column.controller;
+
+import com.todo.app.common.ApiResponse;
+import com.todo.app.domain.column.controller.request.CardCreateRequest;
+import com.todo.app.domain.column.controller.response.CardResponse;
+import com.todo.app.domain.column.service.CardService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class CardController {
+
+    private final CardService cardService;
+
+    public CardController(CardService cardService) {
+        this.cardService = cardService;
+    }
+
+    @PostMapping("/api/columns/{columnId}/cards")
+    public ApiResponse<CardResponse> createCard(@RequestBody CardCreateRequest createRequest, @PathVariable Long columnId) {
+        return ApiResponse.success(
+                HttpStatus.OK,
+                CardResponse.from(cardService.create(createRequest.toCardCreate(columnId)))
+        );
+    }
+
+}

--- a/BE/app/src/main/java/com/todo/app/domain/column/controller/ColumnController.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/controller/ColumnController.java
@@ -3,7 +3,6 @@ package com.todo.app.domain.column.controller;
 import com.todo.app.common.ApiResponse;
 import com.todo.app.domain.column.controller.response.ColumnResponse;
 import com.todo.app.domain.column.service.ColumnService;
-import com.todo.app.domain.column.service.ColumnServiceImpl;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.http.HttpStatus;

--- a/BE/app/src/main/java/com/todo/app/domain/column/controller/request/ActionRequestType.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/controller/request/ActionRequestType.java
@@ -1,0 +1,10 @@
+package com.todo.app.domain.column.controller.request;
+
+public enum ActionRequestType {
+    UPDATE, MOVE_COLUMN;
+
+    public static boolean isUpdate(String action) {
+        return action.toUpperCase().equals(ActionRequestType.UPDATE.name());
+    }
+
+}

--- a/BE/app/src/main/java/com/todo/app/domain/column/controller/request/CardCreateRequest.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/controller/request/CardCreateRequest.java
@@ -1,0 +1,29 @@
+package com.todo.app.domain.column.controller.request;
+
+import com.todo.app.domain.column.domain.CardCreate;
+
+public class CardCreateRequest {
+
+    private String title;
+    private String content;
+
+    public CardCreateRequest() {}
+
+    public CardCreateRequest(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public CardCreate toCardCreate(Long columnId) {
+        return new CardCreate(columnId, title, content);
+    }
+
+}

--- a/BE/app/src/main/java/com/todo/app/domain/column/controller/request/CardUpdateRequest.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/controller/request/CardUpdateRequest.java
@@ -1,0 +1,37 @@
+package com.todo.app.domain.column.controller.request;
+
+
+import com.todo.app.domain.column.domain.CardUpdate;
+
+public class CardUpdateRequest {
+
+    private Long id;
+    private String title;
+    private String content;
+
+    public CardUpdateRequest() {}
+
+    public CardUpdateRequest(Long id, String title, String content) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+
+    public CardUpdate toCardUpdate() {
+        return new CardUpdate(id, title, content);
+    }
+
+}

--- a/BE/app/src/main/java/com/todo/app/domain/column/domain/CardCreate.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/domain/CardCreate.java
@@ -1,0 +1,27 @@
+package com.todo.app.domain.column.domain;
+
+public class CardCreate {
+
+    private Long columnId;
+    private String title;
+    private String content;
+
+    public CardCreate(Long columnId, String title, String content) {
+        this.columnId = columnId;
+        this.title = title;
+        this.content = content;
+    }
+
+    public Long getColumnId() {
+        return columnId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+}

--- a/BE/app/src/main/java/com/todo/app/domain/column/domain/CardUpdate.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/domain/CardUpdate.java
@@ -1,0 +1,26 @@
+package com.todo.app.domain.column.domain;
+
+public class CardUpdate {
+
+    private Long id;
+    private String title;
+    private String content;
+
+    public CardUpdate(Long id, String title, String content) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+}

--- a/BE/app/src/main/java/com/todo/app/domain/column/repository/CardRepository.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/repository/CardRepository.java
@@ -2,6 +2,7 @@ package com.todo.app.domain.column.repository;
 
 import com.todo.app.domain.column.domain.Card;
 import com.todo.app.domain.column.domain.CardCreate;
+import com.todo.app.domain.column.domain.CardUpdate;
 import java.util.List;
 
 public interface CardRepository {
@@ -9,4 +10,6 @@ public interface CardRepository {
     List<Card> findAllBy(Long memberId);
 
     Card save(CardCreate card);
+
+    Card update(CardUpdate card, Long columnId);
 }

--- a/BE/app/src/main/java/com/todo/app/domain/column/repository/CardRepository.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/repository/CardRepository.java
@@ -1,9 +1,12 @@
 package com.todo.app.domain.column.repository;
 
 import com.todo.app.domain.column.domain.Card;
+import com.todo.app.domain.column.domain.CardCreate;
 import java.util.List;
 
 public interface CardRepository {
 
     List<Card> findAllBy(Long memberId);
+
+    Card save(CardCreate card);
 }

--- a/BE/app/src/main/java/com/todo/app/domain/column/repository/CardRepository.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/repository/CardRepository.java
@@ -12,4 +12,6 @@ public interface CardRepository {
     Card save(CardCreate card);
 
     Card update(CardUpdate card, Long columnId);
+
+    void delete(Long cardId);
 }

--- a/BE/app/src/main/java/com/todo/app/domain/column/repository/CardRepositoryImpl.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/repository/CardRepositoryImpl.java
@@ -1,12 +1,17 @@
 package com.todo.app.domain.column.repository;
 
 import com.todo.app.domain.column.domain.Card;
+import com.todo.app.domain.column.domain.CardCreate;
 import com.todo.app.domain.column.entity.CardEntity;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -16,6 +21,18 @@ public class CardRepositoryImpl implements CardRepository {
 
     public CardRepositoryImpl(NamedParameterJdbcTemplate template) {
         this.template = template;
+    }
+
+    @Override
+    public Card save(CardCreate card) {
+
+        String sql = "INSERT INTO tdl_card(tdl_column_id, title, content) "
+                + "VALUES(:tdlColumnId, :title, :content)";
+
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        template.update(sql, mappingCreateCardSqlParameterSource(card), keyHolder);
+
+        return new Card(keyHolder.getKey().longValue(), card.getColumnId(), card.getTitle(), card.getContent(), "web");
     }
 
     @Override
@@ -41,5 +58,12 @@ public class CardRepositoryImpl implements CardRepository {
                 rs.getString("content"),
                 rs.getString("author")
         );
+    }
+
+    private SqlParameterSource mappingCreateCardSqlParameterSource(CardCreate card) {
+        return new MapSqlParameterSource()
+                .addValue("tdlColumnId", card.getColumnId())
+                .addValue("title", card.getTitle())
+                .addValue("content", card.getContent());
     }
 }

--- a/BE/app/src/main/java/com/todo/app/domain/column/repository/CardRepositoryImpl.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/repository/CardRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.todo.app.domain.column.repository;
 
 import com.todo.app.domain.column.domain.Card;
 import com.todo.app.domain.column.domain.CardCreate;
+import com.todo.app.domain.column.domain.CardUpdate;
 import com.todo.app.domain.column.entity.CardEntity;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +37,15 @@ public class CardRepositoryImpl implements CardRepository {
     }
 
     @Override
+    public Card update(CardUpdate card, Long columnId) {
+
+        String sql = "UPDATE tdl_card SET title = :title, content = :content WHERE id = :id";
+        template.update(sql, mappingUdateCardSqlParameterSource(card));
+
+        return new Card(card.getId(), columnId, card.getTitle(), card.getContent(), "web");
+    }
+
+    @Override
     public List<Card> findAllBy(Long memberId) {
         String sql = "SELECT card.id, tdl_column_id, card.title, content, author "
                 + "FROM tdl_card card "
@@ -63,6 +73,13 @@ public class CardRepositoryImpl implements CardRepository {
     private SqlParameterSource mappingCreateCardSqlParameterSource(CardCreate card) {
         return new MapSqlParameterSource()
                 .addValue("tdlColumnId", card.getColumnId())
+                .addValue("title", card.getTitle())
+                .addValue("content", card.getContent());
+    }
+
+    private SqlParameterSource mappingUdateCardSqlParameterSource(CardUpdate card) {
+        return new MapSqlParameterSource()
+                .addValue("id", card.getId())
                 .addValue("title", card.getTitle())
                 .addValue("content", card.getContent());
     }

--- a/BE/app/src/main/java/com/todo/app/domain/column/repository/CardRepositoryImpl.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/repository/CardRepositoryImpl.java
@@ -46,6 +46,15 @@ public class CardRepositoryImpl implements CardRepository {
     }
 
     @Override
+    public void delete(Long cardId) {
+        String sql = "UPDATE tdl_card "
+                + "SET deleted = 1 "
+                + "WHERE id = :cardId";
+
+        template.update(sql, Map.of("cardId", cardId));
+    }
+
+    @Override
     public List<Card> findAllBy(Long memberId) {
         String sql = "SELECT card.id, tdl_column_id, card.title, content, author "
                 + "FROM tdl_card card "

--- a/BE/app/src/main/java/com/todo/app/domain/column/service/CardService.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/service/CardService.java
@@ -1,0 +1,9 @@
+package com.todo.app.domain.column.service;
+
+import com.todo.app.domain.column.domain.Card;
+import com.todo.app.domain.column.domain.CardCreate;
+
+public interface CardService {
+
+    Card create(CardCreate card);
+}

--- a/BE/app/src/main/java/com/todo/app/domain/column/service/CardService.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/service/CardService.java
@@ -2,8 +2,11 @@ package com.todo.app.domain.column.service;
 
 import com.todo.app.domain.column.domain.Card;
 import com.todo.app.domain.column.domain.CardCreate;
+import com.todo.app.domain.column.domain.CardUpdate;
 
 public interface CardService {
 
     Card create(CardCreate card);
+
+    Card update(CardUpdate card, Long columnId);
 }

--- a/BE/app/src/main/java/com/todo/app/domain/column/service/CardService.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/service/CardService.java
@@ -9,4 +9,6 @@ public interface CardService {
     Card create(CardCreate card);
 
     Card update(CardUpdate card, Long columnId);
+
+    void delete(Long cardId);
 }

--- a/BE/app/src/main/java/com/todo/app/domain/column/service/CardServiceImpl.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/service/CardServiceImpl.java
@@ -1,0 +1,21 @@
+package com.todo.app.domain.column.service;
+
+import com.todo.app.domain.column.domain.Card;
+import com.todo.app.domain.column.domain.CardCreate;
+import com.todo.app.domain.column.repository.CardRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CardServiceImpl implements CardService {
+
+    private final CardRepository cardRepository;
+
+    public CardServiceImpl(CardRepository cardRepository) {
+        this.cardRepository = cardRepository;
+    }
+
+    @Override
+    public Card create(CardCreate card) {
+        return cardRepository.save(card);
+    }
+}

--- a/BE/app/src/main/java/com/todo/app/domain/column/service/CardServiceImpl.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/service/CardServiceImpl.java
@@ -24,4 +24,9 @@ public class CardServiceImpl implements CardService {
     public Card update(CardUpdate card, Long columnId) {
         return cardRepository.update(card, columnId);
     }
+
+    @Override
+    public void delete(Long cardId) {
+        cardRepository.delete(cardId);
+    }
 }

--- a/BE/app/src/main/java/com/todo/app/domain/column/service/CardServiceImpl.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/service/CardServiceImpl.java
@@ -2,6 +2,7 @@ package com.todo.app.domain.column.service;
 
 import com.todo.app.domain.column.domain.Card;
 import com.todo.app.domain.column.domain.CardCreate;
+import com.todo.app.domain.column.domain.CardUpdate;
 import com.todo.app.domain.column.repository.CardRepository;
 import org.springframework.stereotype.Service;
 
@@ -17,5 +18,10 @@ public class CardServiceImpl implements CardService {
     @Override
     public Card create(CardCreate card) {
         return cardRepository.save(card);
+    }
+
+    @Override
+    public Card update(CardUpdate card, Long columnId) {
+        return cardRepository.update(card, columnId);
     }
 }


### PR DESCRIPTION
## What is this PR? 👓
- 카드 생성, 제목/내용 수정, 삭제 임시 API 추가

## Key changes 🔑
- [x] 카드 생성 임시 API 추가
- [x] 카드 제목/내용 수정 임시 API 추가
- [x] 카드 삭제 임시 API 추가

## To reviewers 👋
- 카드 이동, 회원 관련 기능을 고려하지 않은 임시 API를 작성했습니다.
    - 카드 이동 로직이 추가되면 카드 생성, 수정 API의 로직이 수정되어야 합니다.
    - JWT 로그인 기능이 구현되면 생성, 수정, 삭제 API의 로직이 수정되어야 합니다.