### PR TITLE
[BE] 카드 weight_value를 역순정렬 반환으로 수정

### DIFF
--- a/BE/app/src/main/java/com/todo/app/domain/column/repository/CardRepositoryImpl.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/repository/CardRepositoryImpl.java
@@ -90,7 +90,8 @@ public class CardRepositoryImpl implements CardRepository {
                 + "LEFT JOIN tdl_column as cl "
                 + "ON tdl_column_id = cl.id "
                 + "WHERE card.deleted = 0 "
-                + "AND member_id = :memberId";
+                + "AND member_id = :memberId "
+                + "ORDER BY weight_value desc";
 
         return template.query(sql, Map.of("memberId", memberId), cardRowMapper());
     }

--- a/BE/app/src/main/java/com/todo/app/domain/column/service/CardServiceImpl.java
+++ b/BE/app/src/main/java/com/todo/app/domain/column/service/CardServiceImpl.java
@@ -67,12 +67,11 @@ public class CardServiceImpl implements CardService {
         final List<Long> weightValues = cardRepository.findWeightsBy(previousCardId, nextCardId);
 
         if (previousCardId == 0L) {
-            return List.of(0L, weightValues.get(0));
+            final Long firstCardWeightValue = weightValues.get(0);
+            return List.of(firstCardWeightValue + (WEIGHT_VALUE_INTERVAL * 2), firstCardWeightValue);
         }
         if (nextCardId == 0L) {
-            final Long lastCardWeightValue = weightValues.get(0);
-
-            return List.of(lastCardWeightValue, lastCardWeightValue + (WEIGHT_VALUE_INTERVAL * 2));
+            return List.of(weightValues.get(0), 0L);
         }
 
         return weightValues;
@@ -80,11 +79,11 @@ public class CardServiceImpl implements CardService {
 
     public void resizeAllWeightValues(final Long columnId) {
         final List<Card> cards = cardRepository.findCardsBy(columnId);
-        long weightValue = WEIGHT_VALUE_INTERVAL;
+        long weightValue = WEIGHT_VALUE_INTERVAL * cards.size();
 
         for (Card card : cards) {
             card.assignWeightValue(weightValue);
-            weightValue += WEIGHT_VALUE_INTERVAL;
+            weightValue -= WEIGHT_VALUE_INTERVAL;
         }
 
         cardRepository.updateWeightValueCards(cards);
@@ -94,6 +93,6 @@ public class CardServiceImpl implements CardService {
         final Long previousWeightValue = weightValues.get(0);
         final Long nextWeightValue = weightValues.get(1);
 
-        return (nextWeightValue - previousWeightValue) <= 1L;
+        return (previousWeightValue - nextWeightValue) <= 1L;
     }
 }


### PR DESCRIPTION
## What is this PR? 👓
카드 weight_value를 역순정렬 반환으로 수정

## Key changes 🔑
* CardService의 ```getWeightValues``` 메서드에서 ```previousCardId```이 0인 경우(카드 맨 앞으로 이동) ```(firstCardWeightValue + (WEIGHT_VALUE_INTERVAL * 2), firstCardWeightValue)``` 반환하고, ```nextCardId```이 0인 경우(카드 맨 뒤로 이동) ```(weightValues.get(0), 0L)``` 반환하도록 수정
* CardService의 ```resizeAllWeightValues``` 메서드에서 ```weight_value```를 큰 값부터 할당하도록 수정 ex) 5000, 4000, 3000 ...
* CardService의 ```isFullWeightValues``` 메서드 수정
* CardRepositoryImpl의 ```findAllBy```메서드 내림차순 정렬로 수정

## To reviewers 👋
